### PR TITLE
Feat: show commit msg length (closes #36)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # install modules
   - npm config set loglevel warn
-  - npm i -g npm
+  - npm i -g npm@5.3
   - npm i
 
 # Post-install test scripts.

--- a/lib/rules/availableRules.js
+++ b/lib/rules/availableRules.js
@@ -10,7 +10,7 @@ const rules = {
     },
   }),
   maxChar: (input, config) => ({
-    message: () => `The commit message is not allowed to be longer as ${config.rules['max-char']}, but is ${input.length}. Consider writing a body.`,
+    message: () => `The commit message is not allowed to be longer as ${config.rules['max-char']} character, but is ${input.length} character long. Consider writing a body.`,
     check: () => {
       let number = config.rules['max-char'];
 
@@ -26,7 +26,7 @@ const rules = {
     },
   }),
   minChar: (input, config) => ({
-    message: () => `The commit message has to be at least ${config.rules['min-char']} character.`,
+    message: () => `The commit message has to be at least ${config.rules['min-char']} character, but is only ${input.length} character long.`,
     check: () => {
       if (input.length < config.rules['min-char']) {
         return false;

--- a/lib/rules/availableRules.js
+++ b/lib/rules/availableRules.js
@@ -10,7 +10,7 @@ const rules = {
     },
   }),
   maxChar: (input, config) => ({
-    message: () => `The commit message is not allowed to be longer as ${config.rules['max-char']}. Consider writing a body.`,
+    message: () => `The commit message is not allowed to be longer as ${config.rules['max-char']}, but is ${input.length}. Consider writing a body.`,
     check: () => {
       let number = config.rules['max-char'];
 

--- a/test/questions.js
+++ b/test/questions.js
@@ -112,7 +112,7 @@ test('COMMIT | validate functions in questions', (t) => {
   const questionsList = questions(config);
 
   t.is(questionsList[2].validate('input text'), true);
-  t.is(questionsList[2].validate('This message has over 72 characters. So this test will definitely fail. I can guarantee that I am telling the truth'), 'The commit message is not allowed to be longer as 72, but is 115. Consider writing a body.\n');
+  t.is(questionsList[2].validate('This message has over 72 characters. So this test will definitely fail. I can guarantee that I am telling the truth'), 'The commit message is not allowed to be longer as 72 character, but is 115 character long. Consider writing a body.\n');
 });
 
 test('COMMIT | when and default functions in questions', (t) => {

--- a/test/questions.js
+++ b/test/questions.js
@@ -112,7 +112,7 @@ test('COMMIT | validate functions in questions', (t) => {
   const questionsList = questions(config);
 
   t.is(questionsList[2].validate('input text'), true);
-  t.is(questionsList[2].validate('This message has over 72 characters. So this test will definitely fail. I can guarantee that I am telling the truth'), 'The commit message is not allowed to be longer as 72. Consider writing a body.\n');
+  t.is(questionsList[2].validate('This message has over 72 characters. So this test will definitely fail. I can guarantee that I am telling the truth'), 'The commit message is not allowed to be longer as 72, but is 115. Consider writing a body.\n');
 });
 
 test('COMMIT | when and default functions in questions', (t) => {

--- a/test/rules/ruleWarningMessages.js
+++ b/test/rules/ruleWarningMessages.js
@@ -11,5 +11,5 @@ test('ruleWarningMessages', (t) => {
     },
   };
   const messages = ruleWaringMessages('input.', config);
-  t.deepEqual(messages, 'The commit message has to be at least 10 character.\nThe commit message can not end with a dot\n');
+  t.deepEqual(messages, 'The commit message has to be at least 10 character, but is only 6 character long.\nThe commit message can not end with a dot\n');
 });


### PR DESCRIPTION
Maybe we should add `character` to the message? Like

> The commit message is not allowed to be longer as 72 character, but is 85 character long. Consider writing a body.

Maybe we should also add the current characters to the warning if there are not enough characters. Like

> The commit message has to be at least 10 character, but is only 8 character long.