### PR TITLE
Docs: Fix typo on installation with yarn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm i -g semantic-git-commit-cli
 ```
 or
 ```sh
-$ yarn add global semantic-git-commit-cli
+$ yarn global add semantic-git-commit-cli
 ```
 
 ## Usage


### PR DESCRIPTION
To install global dependencies with yarn, you should use the command `global` first, instead of `add` (because `global` is not an option of `add`).

closes #45 