### PR TITLE
Chore: drop Node v4 (closes #53)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 sudo: true
 dist: trusty
 node_js:
-  - 4
   - 6
   - 8
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@
 environment:
   matrix:
     # node.js
-    - nodejs_version: 4
     - nodejs_version: 6
     - nodejs_version: 8
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "prepush": "npm test"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "ava": {
     "require": [
       "babel-register",


### PR DESCRIPTION
As we have to update `inquirer` soon, which just supports v6 as well.