### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ module.exports = {
     preset: 'eslint',
     releaseRules: './config/release-rules.js', // optional, only if you want to set up new/modified release rules inside another file
     parserOpts: { // optional, only you want to have emoji commit support
-      headerPattern: /^(?::([\w-]*):)?\s*(\w*):\s*([\s\S]*)$/,
+      headerPattern: /^(?::([\w-]*):)?\s*(\w*):\s*(.*)$/,
       headerCorrespondence: [
         'emoji',
         'tag',
@@ -67,7 +67,7 @@ module.exports = {
   generateNotes: {
     preset: 'eslint',
     parserOpts: { // optional, only you want to have emoji commit support
-      headerPattern: /^(?::([\w-]*):)?\s*(\w*):\s*([\s\S]*)$/,
+      headerPattern: /^(?::([\w-]*):)?\s*(\w*):\s*(.*)$/,
       headerCorrespondence: [
         'emoji',
         'tag',

--- a/README.md
+++ b/README.md
@@ -48,20 +48,40 @@ or
 ```sh
 $ yarn add -D sr-commit-analyzer sr-release-notes-generator conventional-changelog-eslint
 ```
-
-Then, add this in your `package.json` :
-```json
-{
-  "release": {
-    "analyzeCommits": {
-      "path": "sr-commit-analyzer",
-      "preset": "eslint"
+Then, create  a `release.config.js` file in a `config` folder in the root folder of your project :
+```js
+/* eslint-disable no-useless-escape */
+module.exports = {
+  analyzeCommits: {
+    preset: 'eslint',
+    releaseRules: './config/release-rules.js', // optional, only if you want to set up new/modified release rules inside another file
+    parserOpts: { // optional, only you want to have emoji commit support
+      headerPattern: /^(?:\:(\w*)\:)?\s(\w*)\:\s(.*?)(?:\((.*)\))?$/,
+      headerCorrespondence: [
+        'emoji',
+        'tag',
+        'message',
+      ],
     },
-   "generateNotes": {
-      "path": "sr-release-notes-generator",
-      "preset": "eslint"
-    }
-  }
+  },
+  generateNotes: {
+    preset: 'eslint',
+    parserOpts: { // optional, only you want to have emoji commit support
+      headerPattern: /^(?:\:(\w*)\:)?\s(\w*)\:\s(.*?)(?:\((.*)\))?$/,
+      headerCorrespondence: [
+        'emoji',
+        'tag',
+        'message',
+      ],
+    },
+  },
+};
+```
+
+Then, update the  `semantic-release ` script to your `package.json` to this : 
+```json
+"scripts": {
+    "semantic-release": "semantic-release -e ./config/release.config.js",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ module.exports = {
     preset: 'eslint',
     releaseRules: './config/release-rules.js', // optional, only if you want to set up new/modified release rules inside another file
     parserOpts: { // optional, only you want to have emoji commit support
-      headerPattern: /^(?:\:(\w*)\:)?\s(\w*)\:\s(.*?)(?:\((.*)\))?$/,
+      headerPattern: /^(?::([\w-]*):)?\s*(\w*):\s*([\s\S]*)$/,
       headerCorrespondence: [
         'emoji',
         'tag',
@@ -67,7 +67,7 @@ module.exports = {
   generateNotes: {
     preset: 'eslint',
     parserOpts: { // optional, only you want to have emoji commit support
-      headerPattern: /^(?:\:(\w*)\:)?\s(\w*)\:\s(.*?)(?:\((.*)\))?$/,
+      headerPattern: /^(?::([\w-]*):)?\s*(\w*):\s*([\s\S]*)$/,
       headerCorrespondence: [
         'emoji',
         'tag',


### PR DESCRIPTION
Allow sgc to work (with/without emoji support) with new version of semantic release

The initial discussion about this : https://github.com/semantic-release/semantic-release/issues/575
 
A example from regex101 : https://regex101.com/r/MQVrZO/1