### PR TITLE
Docs: Fixed erroneous json comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Example:
 }
 ```
 or type specific delimiters, which will overwrite the global one:
-```json
+```json5
 {
   "delimiter": ":",
   "types": [


### PR DESCRIPTION
The comments in json file before this commit was marked as an error. This was caused as comments were not supposed by json by default.
Fixed it by specifying code type to json5